### PR TITLE
timestamps_fix

### DIFF
--- a/experanto/datasets.py
+++ b/experanto/datasets.py
@@ -457,9 +457,11 @@ class ChunkDataset(Dataset):
             times = times + self.modality_config[device_name].offset
             data, _ = self._experiment.interpolate(times, device=device_name)
             out[device_name] = self.transforms[device_name](data).squeeze(0) # remove dim0 for response/eye_tracker/treadmill
-
-        phase_shifts = self._experiment.devices["responses"]._phase_shifts
-        times_with_phase_shifts = (times - times.min())[:, None] + phase_shifts[None, :]
-        out["timestamps"] = torch.from_numpy(times_with_phase_shifts)
+            if device_name == 'responses':
+                phase_shifts = self._experiment.devices["responses"]._phase_shifts
+                times_with_phase_shifts = (times - times.min())[:, None] + phase_shifts[None, :]
+                out[f"{device_name}_timestamps"] = torch.from_numpy(times_with_phase_shifts)
+            else:
+                out[f"{device_name}_timestamps"] = torch.from_numpy(times)
         return out
 


### PR DESCRIPTION
There was a small bug before, if we use different frequences/chunk sizes before then the times for the last modality in the for loop would be used as times for the responses are not necessarily the times from responses modality

I also checked with Yongrong and Alex - it should not affect the current response-to-response model as they used same sampling rate in the dataloader

I now return all times for multimodal models