### PR TITLE
numerics for knn interpolation and minor clean up

### DIFF
--- a/experanto/datasets.py
+++ b/experanto/datasets.py
@@ -257,9 +257,7 @@ class ChunkDataset(Dataset):
                     # https://github.com/sinzlab/neuralpredictors/blob/2b420058b2c0c029842ba739829114ddfa0f8b50/neuralpredictors/data/transforms.py#L375-L378
                     threshold = 0.01 * np.nanmean(stds)
                     idx = stds[0, :] < threshold  # response std shape: (1, n_neurons)
-                    stds[0, idx] = (
-                        threshold  # setting stds which are smaller than 1 to threshold
-                    )
+                    stds[0, idx] = threshold  # setting stds which are smaller than threshold to threshold
 
                 # if mode is a dict, it will override the means and stds
                 if not isinstance(mode, str):

--- a/experanto/datasets.py
+++ b/experanto/datasets.py
@@ -257,7 +257,9 @@ class ChunkDataset(Dataset):
                     # https://github.com/sinzlab/neuralpredictors/blob/2b420058b2c0c029842ba739829114ddfa0f8b50/neuralpredictors/data/transforms.py#L375-L378
                     threshold = 0.01 * np.nanmean(stds)
                     idx = stds[0, :] < threshold  # response std shape: (1, n_neurons)
-                    stds[0, idx] = threshold  # setting stds which are smaller than threshold to threshold
+                    stds[0, idx] = (
+                        threshold  # setting stds which are smaller than threshold to threshold
+                    )
 
                 # if mode is a dict, it will override the means and stds
                 if not isinstance(mode, str):
@@ -623,10 +625,7 @@ class ChunkDataset(Dataset):
             # convert everything to int to avoid numerical issues
             start_time = int(round(s * self.scale_precision))
             offset = int(
-                round(
-                    sample_dataset.modality_config[device_name].offset
-                    * self.scale_precision
-                )
+                round(self.modality_config[device_name].offset * self.scale_precision)
             )
             time_delta = int(round((1.0 / sampling_rate) * self.scale_precision))
             # Generate times as ints - important as for np.floats the summation is not associative

--- a/experanto/datasets.py
+++ b/experanto/datasets.py
@@ -21,9 +21,11 @@ from torchvision.transforms.v2 import Compose, Lambda, ToTensor
 from .configs import DEFAULT_MODALITY_CONFIG
 from .experiment import Experiment
 from .interpolators import ImageTrial, VideoTrial
-from .intervals import (TimeInterval,
-                        find_intersection_between_two_interval_arrays,
-                        get_stats_for_valid_interval)
+from .intervals import (
+    TimeInterval,
+    find_intersection_between_two_interval_arrays,
+    get_stats_for_valid_interval,
+)
 from .utils import add_behavior_as_channels, replace_nan_with_batch_mean
 
 # see .configs.py for the definition of DEFAULT_MODALITY_CONFIG
@@ -144,7 +146,7 @@ class ChunkDataset(Dataset):
         self.root_folder = Path(root_folder)
         self.data_key = self.get_data_key_from_root_folder(root_folder)
         self.interpolate_precision = interpolate_precision
-        self.scale_precision = 10 ** self.interpolate_precision
+        self.scale_precision = 10**self.interpolate_precision
 
         self.modality_config = instantiate(modality_config)
         self.chunk_sizes, self.sampling_rates, self.chunk_s = {}, {}, {}
@@ -255,7 +257,9 @@ class ChunkDataset(Dataset):
                     # https://github.com/sinzlab/neuralpredictors/blob/2b420058b2c0c029842ba739829114ddfa0f8b50/neuralpredictors/data/transforms.py#L375-L378
                     threshold = 0.01 * np.nanmean(stds)
                     idx = stds[0, :] < threshold  # response std shape: (1, n_neurons)
-                    stds[0, idx] = threshold  # setting stds which are smaller than 1 to threshold
+                    stds[0, idx] = (
+                        threshold  # setting stds which are smaller than 1 to threshold
+                    )
 
                 # if mode is a dict, it will override the means and stds
                 if not isinstance(mode, str):
@@ -620,11 +624,16 @@ class ChunkDataset(Dataset):
 
             # convert everything to int to avoid numerical issues
             start_time = int(round(s * self.scale_precision))
-            offset = int(round(sample_dataset.modality_config[device_name].offset * self.scale_precision))
+            offset = int(
+                round(
+                    sample_dataset.modality_config[device_name].offset
+                    * self.scale_precision
+                )
+            )
             time_delta = int(round((1.0 / sampling_rate) * self.scale_precision))
             # Generate times as ints - important as for np.floats the summation is not associative
             times = start_time + offset + np.arange(chunk_size) * time_delta
-            # scale everything back to truncated values 
+            # scale everything back to truncated values
             times = times.astype(np.float64) / self.scale_precision
 
             data, _ = self._experiment.interpolate(times, device=device_name)

--- a/experanto/datasets.py
+++ b/experanto/datasets.py
@@ -83,7 +83,7 @@ class ChunkDataset(Dataset):
         modality_config: dict = DEFAULT_MODALITY_CONFIG,
         seed: Optional[int] = None,
         safe_interval_threshold: float = 0.5,
-        interpolate_precision: float = 5,
+        interpolate_precision: int = 5,
     ) -> None:
         """
         interpolate_precision: number of digits after the dot to keep, without it we might get different numbers from interpolation

--- a/experanto/datasets.py
+++ b/experanto/datasets.py
@@ -69,198 +69,6 @@ class SimpleChunkedDataset(Dataset):
         return data
 
 
-class Mouse2pStaticImageDataset(Dataset):
-    def __init__(
-        self,
-        root_folder: str,
-        tier: str,
-        offset: float,
-        stim_duration: float,
-        interp_config: dict = DEFAULT_MODALITY_CONFIG,
-    ) -> None:
-        self.root_folder = Path(root_folder)
-        self.tier = tier
-        self.offset = offset
-        self.stim_duration = stim_duration
-        self._experiment = Experiment(
-            root_folder,
-            interp_config,
-        )
-        self.device_names = self._experiment.device_names
-        self.DataPoint = namedtuple("DataPoint", self.device_names)
-        self._read_trials()
-
-    def _read_trials(self):
-        screen = self._experiment.devices["screen"]
-        self._trials = [
-            t
-            for t in screen.trials
-            if isinstance(t, ImageTrial) and t.get_meta("tier") == self.tier
-        ]
-        s_idx = np.array([t.first_frame_idx for t in self._trials])
-        if len(s_idx):
-            self._start_times = screen.timestamps[s_idx]
-        else:
-            self._start_times = np.array([])
-
-    def __len__(self):
-        return len(self._trials)
-
-    def __getitem__(self, idx):
-        assert isinstance(idx, int), "Index must be an integer"
-        data = dict()
-        for device_name, device in self._experiment.devices.items():
-            if device_name == "screen":
-                times = self._start_times[idx]
-            else:
-                Fs = device.sampling_rate
-                times = (
-                    self._start_times[idx]
-                    + self.offset
-                    + np.arange(0, self.stim_duration, 1.0 / Fs)
-                )
-            d, _ = device.interpolate(times)
-            data[device_name] = d.mean(axis=0)
-        return self.DataPoint(**data)
-
-
-class Mouse2pVideoDataset(Dataset):
-    def __init__(
-        self,
-        root_folder: str,
-        tier: str,
-        stim_duration: float,
-        sampling_rate: float,
-        subsample: bool,
-        cut: bool,
-        add_channel: bool,
-        channel_pos: int,
-        interp_config: dict = DEFAULT_MODALITY_CONFIG,
-    ) -> None:
-        """
-        this dataloader returns the full the video resampled to the new freq rate
-        subsampling frames ideally should be outside dataset but in the dataloader augmentations
-
-        :param root_folder: path to the data folder
-        :param tier: train/test/validation
-        :param stim_duration: how many frames to take from the video
-        :param sampling_rate: sampling rate to interpolate
-        :param subsample: if we sample longer video from the non-start position
-        :param cut: if we cut the video up to the stim_duration length or not
-        :param add_channel: if video does not have channels, this flag shows if to add it
-        :param channel_pos: if add_channel True and no channels are in the video, this would be the position to add it
-        """
-        self.root_folder = Path(root_folder)
-        self.tier = tier
-        self.sampling_rate = sampling_rate
-        self.stim_duration = stim_duration
-        self._experiment = Experiment(
-            root_folder,
-            interp_config,
-        )
-        self.device_names = self._experiment.device_names
-        # this is needed to match sensorium order only
-        if "screen" in self.device_names and "responses" in self.device_names:
-            start = ["screen", "responses"]
-            self.device_names = tuple(start) + tuple(
-                set(self.device_names).difference(set(start))
-            )
-        self.subsample = subsample
-        self.cut = cut
-        self.add_channel = add_channel
-        self.channel_pos = channel_pos
-        assert (
-            0 <= channel_pos < 4
-        ), "channels could be extended only for positions [0,3]"
-
-        self.start_time, self.end_time = self._experiment.get_valid_range("screen")
-        self.DataPoint = namedtuple("DataPoint", self.device_names)
-        self.MetaNeuro = namedtuple(
-            "MetaNeuro", ["cell_motor_coordinates", "unit_ids", "fields"]
-        )
-        self._read_trials()
-
-    def _read_trials(self):
-        # reads all videos from valid tiers and saves times for them
-        # also have saves the start and end time if test videos are in between
-        # todo
-        screen = self._experiment.devices["screen"]
-        self._trials = [
-            t
-            for t in screen.trials
-            if isinstance(t, VideoTrial) and t.get_meta("tier") == self.tier
-        ]
-        s_idx = np.array([t.first_frame_idx for t in self._trials])
-        # todo - not sure if it should be t.first_frame_idx + t.num_frames
-        e_idx = np.array([t.first_frame_idx + t.num_frames - 1 for t in self._trials])
-        # todo - this uses the assumption that sampling_rate is less or equal the sampling rate of the screen stimuli
-        if self.cut:
-            assert all(
-                [t.num_frames >= self.stim_duration for t in self._trials]
-            ), "stim_duration should be smaller"
-        if len(s_idx):
-            self._start_times = screen.timestamps[s_idx]
-            self._end_times = screen.timestamps[e_idx]
-        else:
-            self._start_times = np.array([])
-            self._end_times = np.array([])
-
-    def __len__(self):
-        return len(self._trials)
-
-    @property
-    def neurons(self):
-        loc_meta = {
-            "cell_motor_coordinates": [],
-            "unit_ids": [],
-            "fields": [],
-        }
-        if "responses" in self._experiment.devices.keys():
-            # todo - make it lazy loading? and read-only properties?
-            root_folder = self._experiment.devices["responses"].root_folder
-            meta = self._experiment.devices["responses"].load_meta()
-            if "neuron_properties" in meta:
-                cell_motor_coordinates = np.load(
-                    root_folder / meta["neuron_properties"]["cell_motor_coordinates"]
-                )
-                unit_ids = np.load(root_folder / meta["neuron_properties"]["unit_ids"])
-                fields = np.load(root_folder / meta["neuron_properties"]["fields"])
-
-                loc_meta = {
-                    "cell_motor_coordinates": cell_motor_coordinates,
-                    "unit_ids": unit_ids,
-                    "fields": fields,
-                }
-
-        return self.MetaNeuro(**loc_meta)
-
-    def __getitem__(self, idx):
-        """
-
-        :param idx: idx of the video
-        :return: this would return video in data['screen'] with shape of [t, h, w]
-        """
-        fs = self.sampling_rate
-        times = np.arange(self._start_times[idx], self._end_times[idx], 1 / fs)
-        # get all times possible
-        # cut is needed
-        if self.cut:
-            if self.subsample:
-                start = np.random.randint(0, len(times) - self.stim_duration)
-                times = times[start : start + self.stim_duration]
-            else:
-                times = times[: self.stim_duration]
-
-        data, _ = self._experiment.interpolate(times)
-
-        if self.add_channel and len(data["screen"].shape) != 4:
-            data["screen"] = np.expand_dims(data["screen"], axis=self.channel_pos)
-        # this hack matches the shape for sensorium models
-        if "responses" in data:
-            data["responses"] = data["responses"].T
-        return self.DataPoint(**data)
-
-
 class ChunkDataset(Dataset):
     def __init__(
         self,
@@ -275,8 +83,11 @@ class ChunkDataset(Dataset):
         modality_config: dict = DEFAULT_MODALITY_CONFIG,
         seed: Optional[int] = None,
         safe_interval_threshold: float = 0.5,
+        interpolate_precision: float = 5,
     ) -> None:
         """
+        interpolate_precision: number of digits after the dot to keep, without it we might get different numbers from interpolation
+
         The full modality config is a nested dictionary.
         The following is an example of a modality config for a screen, responses, eye_tracker, and treadmill:
 
@@ -332,6 +143,8 @@ class ChunkDataset(Dataset):
         """
         self.root_folder = Path(root_folder)
         self.data_key = self.get_data_key_from_root_folder(root_folder)
+        self.interpolate_precision = interpolate_precision
+        self.scale_precision = 10 ** self.interpolate_precision
 
         self.modality_config = instantiate(modality_config)
         self.chunk_sizes, self.sampling_rates, self.chunk_s = {}, {}, {}
@@ -438,8 +251,11 @@ class ChunkDataset(Dataset):
                     self._experiment.devices[device_name].root_folder / "meta/stds.npy"
                 )
                 if device_name == "responses":
-                    idx = stds[0, :] < 1  # response std shape: (1, n_neurons)
-                    stds[0, idx] = 1  # setting stds which are smaller than 1 to 1
+                    # same as in neuralpredictors before
+                    # https://github.com/sinzlab/neuralpredictors/blob/2b420058b2c0c029842ba739829114ddfa0f8b50/neuralpredictors/data/transforms.py#L375-L378
+                    threshold = 0.01 * np.nanmean(stds)
+                    idx = stds[0, :] < threshold  # response std shape: (1, n_neurons)
+                    stds[0, idx] = threshold  # setting stds which are smaller than 1 to threshold
 
                 # if mode is a dict, it will override the means and stds
                 if not isinstance(mode, str):
@@ -802,8 +618,14 @@ class ChunkDataset(Dataset):
             chunk_size = self.chunk_sizes[device_name]
             chunk_s = chunk_size / sampling_rate
 
-            times = np.linspace(s, s + chunk_s, chunk_size, endpoint=False)
-            times = times + self.modality_config[device_name].offset
+            # convert everything to int to avoid numerical issues
+            start_time = int(round(s * self.scale_precision))
+            offset = int(round(sample_dataset.modality_config[device_name].offset * self.scale_precision))
+            time_delta = int(round((1.0 / sampling_rate) * self.scale_precision))
+            # Generate times as ints - important as for np.floats the summation is not associative
+            times = start_time + offset + np.arange(chunk_size) * time_delta
+            # scale everything back to truncated values 
+            times = times.astype(np.float64) / self.scale_precision
 
             data, _ = self._experiment.interpolate(times, device=device_name)
             out[device_name] = self.transforms[device_name](data).squeeze(
@@ -815,12 +637,7 @@ class ChunkDataset(Dataset):
                     out[device_name] = out[device_name].permute(0, 3, 1, 2)
                 if out[device_name].shape[0] == chunk_size:
                     out[device_name] = out[device_name].transpose(0, 1)
-
-            if device_name == "responses":
-                if self._experiment.devices["responses"].use_phase_shifts:
-                    phase_shifts = self._experiment.devices["responses"]._phase_shifts
-                    times = times[:, None] + phase_shifts[None, :]
-
+            # all signals are interpolated for the same times, so no phase shifts adjustment is needed
             times = torch.from_numpy(times)
             if self.normalize_timestamps:
                 times = times - self._experiment.devices["responses"].start_time


### PR DESCRIPTION
* implements response normalization as in neural predictors (remove hardcoded threshold=1)
* minor code cleanup (remove non-used code)
* fix numerical issues when querying timepoints (truncate times to the 5th digit after the dot. Due to big value of start time in real datasets we cannot just cast the array to float32 but actually need float64)
* removes incorrect times for responses in __getitem__ (as interpolation implies that the times are same for all the neurons)