### PR TITLE
Benchmarking Dataloaders

### DIFF
--- a/experanto/utils.py
+++ b/experanto/utils.py
@@ -152,8 +152,10 @@ class MultiEpochsDataLoader(torch.utils.data.DataLoader):
                 print(f"Batch {i+1}: {batch_times[-1]:.4f}s")
 
         avg_time = sum(batch_times) / len(batch_times)
-        std_time = (sum((t - avg_time) ** 2 for t in batch_times) / len(batch_times)) ** 0.5
-        return {'avg_time': avg_time, 'std_time': std_time, 'batch_times': batch_times}
+        std_time = (
+            sum((t - avg_time) ** 2 for t in batch_times) / len(batch_times)
+        ) ** 0.5
+        return {"avg_time": avg_time, "std_time": std_time, "batch_times": batch_times}
 
 
 # borrowed with <3 from


### PR DESCRIPTION
PR Draft, only contains a benchmarking function for the Multiepochsdataloader class.
Pretty straight forward but works nicely.

I also have benchmarks for the Interpolators and the Decoding / Numpy loading speeds but I'm not sure if we need that inside the experanto repo, it could be it's own script inside the repo that generates data or same as here a benchmark method for the classes but it's a bit more complicated to loop over the actual data.