### PR TITLE
Use yaml.safe_load/safe_dump for meta YAML

### DIFF
--- a/examples/sensorium/interpolator_demo.ipynb
+++ b/examples/sensorium/interpolator_demo.ipynb
@@ -57,7 +57,7 @@
     ")\n",
     "\n",
     "with open(\"/Users/fabee/Data/sinzlab-data/dataset0/eye_tracker/meta.yml\", \"w\") as f:\n",
-    "    yaml.dump(meta, f)"
+    "    yaml.safe_dump(meta, f)"
    ]
   },
   {

--- a/experanto/interpolators.py
+++ b/experanto/interpolators.py
@@ -26,7 +26,7 @@ class Interpolator:
 
     def load_meta(self):
         with open(self.root_folder / "meta.yml") as f:
-            meta = yaml.load(f, Loader=yaml.SafeLoader)
+            meta = yaml.safe_load(f)
         return meta
 
     @abstractmethod
@@ -46,7 +46,7 @@ class Interpolator:
     @staticmethod
     def create(root_folder: str, cache_data: bool = False, **kwargs) -> "Interpolator":
         with open(Path(root_folder) / "meta.yml", "r") as file:
-            meta_data = yaml.load(file, Loader=yaml.SafeLoader)
+            meta_data = yaml.safe_load(file)
         modality = meta_data.get("modality")
 
         if modality == "sequence":

--- a/tests/create_screen_data.py
+++ b/tests/create_screen_data.py
@@ -29,7 +29,7 @@ def create_screen_data(
         for i in range(min(image_frame_count, n_frames)):
             np.save(data_dir / f"{i:05d}.npy", frames[i])
             with open(meta_dir / f"{i:05d}.yml", "w") as f:
-                yaml.dump(
+                yaml.safe_dump(
                     {
                         "first_frame_idx": i,
                         "image_size": list(frame_shape),
@@ -53,7 +53,7 @@ def create_screen_data(
                 video_array = np.stack(chunk, axis=0)
                 np.save(data_dir / f"{vid_idx+image_frame_count:05d}.npy", video_array)
                 with open(meta_dir / f"{vid_idx+image_frame_count:05d}.yml", "w") as f:
-                    yaml.dump(
+                    yaml.safe_dump(
                         {
                             "first_frame_idx": start_vid + start,
                             "num_frames": len(chunk),
@@ -65,7 +65,7 @@ def create_screen_data(
                     )
 
         with open(SCREEN_ROOT / "meta.yml", "w") as f:
-            yaml.dump(
+            yaml.safe_dump(
                 {
                     "modality": "screen",
                     "frame_rate": fps,

--- a/tests/create_sequence_data.py
+++ b/tests/create_sequence_data.py
@@ -65,7 +65,7 @@ def create_sequence_data(
             np.save(SEQUENCE_ROOT / "meta" / "phase_shifts.npy", shifts)
 
         with open(SEQUENCE_ROOT / "meta.yml", "w") as f:
-            yaml.dump(meta, f)
+            yaml.safe_dump(meta, f)
 
         yield timestamps, data, shifts if shifts_per_signal else None
     finally:

--- a/tests/create_time_intervals_data.py
+++ b/tests/create_time_intervals_data.py
@@ -69,7 +69,7 @@ def create_time_interval_data(
         }
 
         with open(TIME_INTERVAL_ROOT / "meta.yml", "w") as f:
-            yaml.dump(meta, f)
+            yaml.safe_dump(meta, f)
 
         # Save interval files
         test_array = np.array(test_intervals, dtype=np.float64)


### PR DESCRIPTION
### Summary
Replaced `yaml.load` / `yaml.dump` with `yaml.safe_load` / `yaml.safe_dump` in meta YAML handling.

### Reason
- Prevents arbitrary object construction and avoids Python-specific YAML tags.  
- Meta files only require standard Python types, so `safe_*` functions are sufficient and more secure.

### Verification
- `pytest` passes locally  

Closes #94 