### PR TITLE
docs: clarify installation requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,36 @@
 # Experanto
+
 Experanto is a Python package designed for interpolating recordings and stimuli in neuroscience experiments. It enables users to load single or multiple experiments and create efficient dataloaders for machine learning applications.
 
 ## Installation
+
 To install Experanto, clone locally and run:
+
 ```bash
+pip install -r requirements.txt
 pip install -e /path_to/experanto
 ```
 
 To replicate the `generate_sample` example, install:
+
 ```bash
 pip install -e /path_to/allen_exporter
 ```
+
 (Repository: [allen_exporter](https://github.com/sensorium-competition/allen-exporter))
 
 To replicate the `sensorium_example`, also install the following with their dependencies:
+
 ```bash
 pip install -e /path_to/neuralpredictors
 ```
+
 (Repository: [neuralpredictors](https://github.com/sinzlab/neuralpredictors))
 
 ```bash
 pip install -e /path_to/sensorium_2023
 ```
+
 (Repository: [sensorium_2023](https://github.com/ecker-lab/sensorium_2023))
 
 Ensure you replace `/path_to/` with the actual path to the cloned repositories.
-

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Experanto is a Python package designed for interpolating recordings and stimuli 
 To install Experanto, clone locally and run:
 
 ```bash
-pip install -r requirements.txt
+pip install -r /path_to/experanto/requirements.txt
 pip install -e /path_to/experanto
 ```
 


### PR DESCRIPTION
Hi team! 👋

I am getting my local development environment set up to begin contributing. 

While following the installation guide, I noticed that running the standard `pip install -e .` step threw a `ModuleNotFoundError` for `numpy` because the dependencies in `requirements.txt` weren't installed in the environment first. 

I've added a quick line to the `README.md` to explicitly mention running `pip install -r requirements.txt` before the editable install to help smooth out the onboarding process for future contributors. 

Local tests (`pytest`) are passing completely green on my end (284 passed). Let me know if you need any adjustments to this!