### PR TITLE
Fix doc building and version constraints and allow manual dispatching of CI pipelines

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - '**'
+  workflow_dispatch:
 
 jobs:
   build-docs:
@@ -14,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request' &&
         github.repository != github.event.pull_request.head.repo.full_name

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - '**'
+  workflow_dispatch:
 
 jobs:
   ruff:
@@ -14,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request' &&
         github.repository != github.event.pull_request.head.repo.full_name

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install tools
         run: |
           python -m pip install --upgrade pip
-          pip install "black[jupyter]==25.1.0" isort==6.0.1
+          pip install -e ".[dev]"
 
       - name: Run Black and Isort
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
             fi
 
           elif [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "PR from fork: Running black and isort in check mode"
+            echo "PR or manual run: Running black and isort in check mode"
             black --check . || { echo "Black formatting issues found. Run 'black .' to fix."; exit 1; }
             isort --check-only . || { echo "isort import order issues found. Run 'isort .' to fix."; exit 1; }
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - '**'
+  workflow_dispatch:
 
 jobs:
   test:
@@ -14,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request' &&
         github.repository != github.event.pull_request.head.repo.full_name
@@ -47,6 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request' &&
         github.repository != github.event.pull_request.head.repo.full_name
@@ -72,8 +75,8 @@ jobs:
             echo "Push event in same repo: Running black and isort with auto-format and commit"
             black .
             isort .
-            git config user.name "github-actions"
-            git config user.email "github-actions@github.com"
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             if ! git diff --quiet; then
               git commit -am "style: auto-format with black and isort"
               git push
@@ -81,7 +84,7 @@ jobs:
               echo "No formatting changes to commit."
             fi
 
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          elif [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "PR from fork: Running black and isort in check mode"
             black --check . || { echo "Black formatting issues found. Run 'black .' to fix."; exit 1; }
             isort --check-only . || { echo "isort import order issues found. Run 'isort .' to fix."; exit 1; }
@@ -95,6 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request' &&
         github.repository != github.event.pull_request.head.repo.full_name

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.12"
 
 python:
   install:

--- a/docs/.claude/settings.local.json
+++ b/docs/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git:*)"
+    ]
+  }
+}

--- a/docs/.claude/settings.local.json
+++ b/docs/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(git:*)"
-    ]
-  }
-}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = "experanto"
+project = "Experanto"
 copyright = f"{datetime.today().strftime('%Y')}, sinzlab"
 author = "sinzlab"
 release = "0.1"
@@ -83,6 +83,8 @@ autodoc_mock_imports = [
     "optree",
     "rootutils",
     "numba",
+    "numpy",
+    "PyYAML",
 ]
 
 # -- Intersphinx settings (cross-references to external docs) ----------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -84,7 +84,7 @@ autodoc_mock_imports = [
     "rootutils",
     "numba",
     "numpy",
-    "PyYAML",
+    "yaml",
 ]
 
 # -- Intersphinx settings (cross-references to external docs) ----------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1"
 description = "Python package to interpolate recordings and stimuli of neuroscience experiments"
 readme = "README.md"
 requires-python = ">=3.9"
+# When adding or removing dependencies, also update autodoc_mock_imports in docs/source/conf.py if necessary.
 dependencies = [
     "scipy>=1.13.1",
     "jaxtyping>=0.2.30",
@@ -21,7 +22,9 @@ dependencies = [
 dev = [
     "pytest==8.3.5",
     "pytest-cov>=7.0.0",
-    "pyright",
+    "pyright==1.1.408",
+    "black[jupyter]==25.1.0",
+    "isort==6.0.1",
     "hypothesis>=6.0",
     "ruff==0.15.6",
 ]


### PR DESCRIPTION
## Description
- After introduction of spikes interpolator, the building of the docs failed because readthedocs is building with python v3.9 which doesn't support numba in the specified version
- The CI failed to detect this, because it runs in v3.12
- I also added black and isort to dev dependency group with version constraints
- constrained the version of pyright
- I make use of the dev dependency group in CI to have a single place of definition for dependency versions
- I renamed "experanto" string in readthedocs to capitalized version, matching it to other places
- I introduced manual dispatching of CI workflows
- The name and email of Github Actions Bot was adjusted according to https://github.com/actions/checkout?tab=readme-ov-file#push-a-commit-to-a-pr-using-the-built-in-token